### PR TITLE
Setup production API

### DIFF
--- a/utils/commonAxios.ts
+++ b/utils/commonAxios.ts
@@ -3,7 +3,9 @@ import axios, { AxiosError } from 'axios'
 const instance = axios.create()
 let url: string
 if (process.env.NODE_ENV === 'production') {
-  // production url
+  url = 'https://e-shoku.herokuapp.com/api'
+} else if (process.env.API_CONNECTION === 'heroku') {
+  url = 'https://e-shoku.herokuapp.com/api'
 } else {
   const apiPort = process.env.API_PORT || 8000
   url = `http://localhost:${apiPort}/api`


### PR DESCRIPTION
## 概要
本番用バックエンド（Heroku）との接続を実装した。
## Memo
開発時に本番用バックエンドを用いることができるモードも実装した。  
`env.local`等で環境変数`API_CONNECTION='heroku'`を設定することで有効化可能。 
   
このモードは特別な場合のみ使用してください。